### PR TITLE
Possibly more accurate selection (probably not really an issue)

### DIFF
--- a/Demo/XYPieChart/XYPieChart.m
+++ b/Demo/XYPieChart/XYPieChart.m
@@ -525,14 +525,14 @@ static CGPathRef CGPathCreateArc(CGPoint center, CGFloat radius, CGFloat startAn
 - (void)touchesMoved:(NSSet *)touches withEvent:(UIEvent *)event
 {
     UITouch *touch = [touches anyObject];
-    CGPoint point = [touch locationInView:self];
+    CGPoint point = [touch locationInView:_pieView];
     [self getCurrentSelectedOnTouch:point];
 }
 
 - (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event
 {
     UITouch *touch = [touches anyObject];
-    CGPoint point = [touch locationInView:self];
+    CGPoint point = [touch locationInView:_pieView];
     NSInteger selectedIndex = [self getCurrentSelectedOnTouch:point];
     [self notifyDelegateOfSelectionChangeFrom:_selectedSliceIndex to:selectedIndex];
     [self touchesCancelled:touches withEvent:event];

--- a/XYPieChart/XYPieChart.m
+++ b/XYPieChart/XYPieChart.m
@@ -48,7 +48,7 @@
 {
     return [NSString stringWithFormat:@"value:%f, percentage:%0.0f, start:%d, end:%d", _value, _percentage, _startAngle/M_PI*180, _endAngle/M_PI*180];
 }
-+ (BOOL)needsDisplayForKey:(NSString *)key 
++ (BOOL)needsDisplayForKey:(NSString *)key
 {
     if ([key isEqualToString:@"startAngle"] || [key isEqualToString:@"endAngle"]) {
         return YES;
@@ -74,7 +74,7 @@
     NSNumber *currentAngle = [[self presentationLayer] valueForKey:key];
     if(!currentAngle) currentAngle = from;
     [arcAnimation setFromValue:currentAngle];
-    [arcAnimation setToValue:to];         
+    [arcAnimation setToValue:to];
     [arcAnimation setDelegate:delegate];
     [arcAnimation setTimingFunction:[CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionDefault]];
     [self addAnimation:arcAnimation forKey:key];
@@ -82,7 +82,7 @@
 }
 @end
 
-@interface XYPieChart (Private) 
+@interface XYPieChart (Private)
 - (void)updateTimerFired:(NSTimer *)timer;
 - (SliceLayer *)createSliceLayer;
 - (CGSize)sizeThatFitsString:(NSString *)string;
@@ -95,7 +95,7 @@
     NSInteger _selectedSliceIndex;
     //pie view, contains all slices
     UIView  *_pieView;
-    
+
     //animation control
     NSTimer *_animationTimer;
     NSMutableArray *_animations;
@@ -116,14 +116,14 @@ static NSUInteger kDefaultSliceZOrder = 100;
 @synthesize selectedSliceOffsetRadius = _selectedSliceOffsetRadius;
 @synthesize showPercentage = _showPercentage;
 
-static CGPathRef CGPathCreateArc(CGPoint center, CGFloat radius, CGFloat startAngle, CGFloat endAngle) 
+static CGPathRef CGPathCreateArc(CGPoint center, CGFloat radius, CGFloat startAngle, CGFloat endAngle)
 {
     CGMutablePathRef path = CGPathCreateMutable();
     CGPathMoveToPoint(path, NULL, center.x, center.y);
-    
+
     CGPathAddArc(path, NULL, center.x, center.y, radius, startAngle, endAngle, 0);
     CGPathCloseSubpath(path);
-    
+
     return path;
 }
 
@@ -136,20 +136,20 @@ static CGPathRef CGPathCreateArc(CGPoint center, CGFloat radius, CGFloat startAn
         _pieView = [[UIView alloc] initWithFrame:frame];
         [_pieView setBackgroundColor:[UIColor clearColor]];
         [self addSubview:_pieView];
-        
+
         _selectedSliceIndex = -1;
         _animations = [[NSMutableArray alloc] init];
-        
+
         _animationSpeed = 0.5;
         _startPieAngle = M_PI_2*3;
         _selectedSliceStroke = 3.0;
-        
+
         self.pieRadius = MIN(frame.size.width/2, frame.size.height/2) - 10;
         self.pieCenter = CGPointMake(frame.size.width/2, frame.size.height/2);
         self.labelFont = [UIFont boldSystemFontOfSize:MAX((int)self.pieRadius/10, 5)];
         _labelRadius = _pieRadius/2;
         _selectedSliceOffsetRadius = MAX(10, _pieRadius/10);
-        
+
         _showLabel = YES;
         _showPercentage = YES;
     }
@@ -175,21 +175,21 @@ static CGPathRef CGPathCreateArc(CGPoint center, CGFloat radius, CGFloat startAn
         _pieView = [[UIView alloc] initWithFrame:self.bounds];
         [_pieView setBackgroundColor:[UIColor clearColor]];
         [self insertSubview:_pieView atIndex:0];
-        
+
         _selectedSliceIndex = -1;
         _animations = [[NSMutableArray alloc] init];
-        
+
         _animationSpeed = 0.5;
         _startPieAngle = M_PI_2*3;
         _selectedSliceStroke = 3.0;
-        
+
         CGRect bounds = [[self layer] bounds];
         self.pieRadius = MIN(bounds.size.width/2, bounds.size.height/2) - 10;
         self.pieCenter = CGPointMake(bounds.size.width/2, bounds.size.height/2);
         self.labelFont = [UIFont boldSystemFontOfSize:MAX((int)self.pieRadius/10, 5)];
         _labelRadius = _pieRadius/2;
         _selectedSliceOffsetRadius = MAX(10, _pieRadius/10);
-        
+
         _showLabel = YES;
         _showPercentage = YES;
     }
@@ -232,7 +232,7 @@ static CGPathRef CGPathCreateArc(CGPoint center, CGFloat radius, CGFloat startAn
         else
             label = [NSString stringWithFormat:@"%0.0f", layer.value];
         CGSize size = [label sizeWithFont:self.labelFont];
-        
+
         if(M_PI*2*_labelRadius*layer.percentage < MAX(size.width,size.height))
         {
             [textLayer setString:@""];
@@ -274,66 +274,66 @@ static CGPathRef CGPathCreateArc(CGPoint center, CGFloat radius, CGFloat startAn
 
 - (void)reloadData
 {
-    if (_dataSource && !_animationTimer) 
+    if (_dataSource && !_animationTimer)
     {
         CALayer *parentLayer = [_pieView layer];
         NSArray *slicelayers = [parentLayer sublayers];
-        
+
         _selectedSliceIndex = -1;
         [slicelayers enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
             SliceLayer *layer = (SliceLayer *)obj;
             if(layer.isSelected)
                 [self setSliceDeselectedAtIndex:idx];
         }];
-        
+
         double startToAngle = 0.0;
         double endToAngle = startToAngle;
-        
+
         NSUInteger sliceCount = [_dataSource numberOfSlicesInPieChart:self];
-        
+
         double sum = 0.0;
         double values[sliceCount];
         for (int index = 0; index < sliceCount; index++) {
             values[index] = [_dataSource pieChart:self valueForSliceAtIndex:index];
             sum += values[index];
         }
-        
+
         double angles[sliceCount];
         for (int index = 0; index < sliceCount; index++) {
             double div;
             if (sum == 0)
                 div = 0;
             else
-                div = values[index] / sum; 
+                div = values[index] / sum;
             angles[index] = M_PI * 2 * div;
         }
 
         [CATransaction begin];
         [CATransaction setAnimationDuration:_animationSpeed];
-        
+
         [_pieView setUserInteractionEnabled:NO];
-        
+
         __block NSMutableArray *layersToRemove = nil;
         [CATransaction setCompletionBlock:^{
-            
+
             [layersToRemove enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
                 [obj removeFromSuperlayer];
             }];
-            
+
             [layersToRemove removeAllObjects];
-            
+
             for(SliceLayer *layer in _pieView.layer.sublayers)
             {
                 [layer setZPosition:kDefaultSliceZOrder];
             }
-            
+
             [_pieView setUserInteractionEnabled:YES];
         }];
-        
+
         BOOL isOnStart = ([slicelayers count] == 0 && sliceCount);
         NSInteger diff = sliceCount - [slicelayers count];
         layersToRemove = [NSMutableArray arrayWithArray:slicelayers];
-        
+
         BOOL isOnEnd = ([slicelayers count] && (sliceCount == 0 || sum <= 0));
         if(isOnEnd)
         {
@@ -341,17 +341,17 @@ static CGPathRef CGPathCreateArc(CGPoint center, CGFloat radius, CGFloat startAn
                 [self updateLabelForLayer:layer value:0];
                 [layer createArcAnimationForKey:@"startAngle"
                                       fromValue:[NSNumber numberWithDouble:_startPieAngle]
-                                        toValue:[NSNumber numberWithDouble:_startPieAngle] 
+                                        toValue:[NSNumber numberWithDouble:_startPieAngle]
                                        Delegate:self];
-                [layer createArcAnimationForKey:@"endAngle" 
+                [layer createArcAnimationForKey:@"endAngle"
                                       fromValue:[NSNumber numberWithDouble:_startPieAngle]
-                                        toValue:[NSNumber numberWithDouble:_startPieAngle] 
+                                        toValue:[NSNumber numberWithDouble:_startPieAngle]
                                        Delegate:self];
             }
             [CATransaction commit];
             return;
         }
-        
+
         for(int index = 0; index < sliceCount; index ++)
         {
             SliceLayer *layer;
@@ -359,7 +359,7 @@ static CGPathRef CGPathCreateArc(CGPoint center, CGFloat radius, CGFloat startAn
             endToAngle += angle;
             double startFromAngle = _startPieAngle + startToAngle;
             double endFromAngle = _startPieAngle + endToAngle;
-            
+
             if( index >= [slicelayers count] )
             {
                 layer = [self createSliceLayer];
@@ -384,7 +384,7 @@ static CGPathRef CGPathCreateArc(CGPoint center, CGFloat radius, CGFloat startAn
                 }
                 else if(diff < 0)
                 {
-                    while(diff < 0) 
+                    while(diff < 0)
                     {
                         [onelayer removeFromSuperlayer];
                         [parentLayer addSublayer:onelayer];
@@ -399,7 +399,7 @@ static CGPathRef CGPathCreateArc(CGPoint center, CGFloat radius, CGFloat startAn
                     }
                 }
             }
-            
+
             layer.percentage = (angle/2)/M_PI;
             layer.value = values[index];
             UIColor *color = nil;
@@ -407,21 +407,21 @@ static CGPathRef CGPathCreateArc(CGPoint center, CGFloat radius, CGFloat startAn
             {
                 color = [_dataSource pieChart:self colorForSliceAtIndex:index];
             }
-            
+
             if(!color)
             {
                 color = [UIColor colorWithHue:((index/8)%20)/20.0+0.02 saturation:(index%8+3)/10.0 brightness:91/100.0 alpha:1];
             }
-            
+
             [layer setFillColor:color.CGColor];
             [self updateLabelForLayer:layer value:values[index]];
             [layer createArcAnimationForKey:@"startAngle"
                                   fromValue:[NSNumber numberWithDouble:startFromAngle]
-                                    toValue:[NSNumber numberWithDouble:startToAngle+_startPieAngle] 
+                                    toValue:[NSNumber numberWithDouble:startToAngle+_startPieAngle]
                                    Delegate:self];
-            [layer createArcAnimationForKey:@"endAngle" 
+            [layer createArcAnimationForKey:@"endAngle"
                                   fromValue:[NSNumber numberWithDouble:endFromAngle]
-                                    toValue:[NSNumber numberWithDouble:endToAngle+_startPieAngle] 
+                                    toValue:[NSNumber numberWithDouble:endToAngle+_startPieAngle]
                                    Delegate:self];
             startToAngle = endToAngle;
         }
@@ -442,25 +442,25 @@ static CGPathRef CGPathCreateArc(CGPoint center, CGFloat radius, CGFloat startAn
 #pragma mark - Animation Delegate + Run Loop Timer
 
 - (void)updateTimerFired:(NSTimer *)timer;
-{   
+{
     CALayer *parentLayer = [_pieView layer];
     NSArray *pieLayers = [parentLayer sublayers];
 
     [pieLayers enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
-        
+
         NSNumber *presentationLayerStartAngle = [[obj presentationLayer] valueForKey:@"startAngle"];
         CGFloat interpolatedStartAngle = [presentationLayerStartAngle doubleValue];
-        
+
         NSNumber *presentationLayerEndAngle = [[obj presentationLayer] valueForKey:@"endAngle"];
         CGFloat interpolatedEndAngle = [presentationLayerEndAngle doubleValue];
 
         CGPathRef path = CGPathCreateArc(_pieCenter, _pieRadius, interpolatedStartAngle, interpolatedEndAngle);
         [obj setPath:path];
         CFRelease(path);
-        
+
         {
             CALayer *labelLayer = [[obj sublayers] objectAtIndex:0];
-            CGFloat interpolatedMidAngle = (interpolatedEndAngle + interpolatedStartAngle) / 2;        
+            CGFloat interpolatedMidAngle = (interpolatedEndAngle + interpolatedStartAngle) / 2;
             [CATransaction setDisableActions:YES];
             [labelLayer setPosition:CGPointMake(_pieCenter.x + (_labelRadius * cos(interpolatedMidAngle)), _pieCenter.y + (_labelRadius * sin(interpolatedMidAngle)))];
             [CATransaction setDisableActions:NO];
@@ -474,14 +474,14 @@ static CGPathRef CGPathCreateArc(CGPoint center, CGFloat radius, CGFloat startAn
         static float timeInterval = 1.0/60.0;
         _animationTimer= [NSTimer scheduledTimerWithTimeInterval:timeInterval target:self selector:@selector(updateTimerFired:) userInfo:nil repeats:YES];
     }
-    
+
     [_animations addObject:anim];
 }
 
 - (void)animationDidStop:(CAAnimation *)anim finished:(BOOL)animationCompleted
 {
     [_animations removeObject:anim];
-    
+
     if ([_animations count] == 0) {
         [_animationTimer invalidate];
         _animationTimer = nil;
@@ -493,16 +493,16 @@ static CGPathRef CGPathCreateArc(CGPoint center, CGFloat radius, CGFloat startAn
 - (NSInteger)getCurrentSelectedOnTouch:(CGPoint)point
 {
     __block NSUInteger selectedIndex = -1;
-    
+
     CGAffineTransform transform = CGAffineTransformIdentity;
-    
+
     CALayer *parentLayer = [_pieView layer];
     NSArray *pieLayers = [parentLayer sublayers];
-    
+
     [pieLayers enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
         SliceLayer *pieLayer = (SliceLayer *)obj;
         CGPathRef path = [pieLayer path];
-        
+
         if (CGPathContainsPoint(path, &transform, point, 0)) {
             [pieLayer setLineWidth:_selectedSliceStroke];
             [pieLayer setStrokeColor:[UIColor whiteColor].CGColor];
@@ -525,14 +525,14 @@ static CGPathRef CGPathCreateArc(CGPoint center, CGFloat radius, CGFloat startAn
 - (void)touchesMoved:(NSSet *)touches withEvent:(UIEvent *)event
 {
     UITouch *touch = [touches anyObject];
-    CGPoint point = [touch locationInView:self];
+    CGPoint point = [touch locationInView:_pieView];
     [self getCurrentSelectedOnTouch:point];
 }
 
 - (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event
 {
     UITouch *touch = [touches anyObject];
-    CGPoint point = [touch locationInView:self];
+    CGPoint point = [touch locationInView:_pieView];
     NSInteger selectedIndex = [self getCurrentSelectedOnTouch:point];
     [self notifyDelegateOfSelectionChangeFrom:_selectedSliceIndex to:selectedIndex];
     [self touchesCancelled:touches withEvent:event];
@@ -542,7 +542,7 @@ static CGPathRef CGPathCreateArc(CGPoint center, CGFloat radius, CGFloat startAn
 {
     CALayer *parentLayer = [_pieView layer];
     NSArray *pieLayers = [parentLayer sublayers];
-    
+
     for (SliceLayer *pieLayer in pieLayers) {
         [pieLayer setZPosition:kDefaultSliceZOrder];
         [pieLayer setLineWidth:0.0];
@@ -553,16 +553,16 @@ static CGPathRef CGPathCreateArc(CGPoint center, CGFloat radius, CGFloat startAn
 
 - (void)notifyDelegateOfSelectionChangeFrom:(NSUInteger)previousSelection to:(NSUInteger)newSelection
 {
-    if (previousSelection != newSelection) 
+    if (previousSelection != newSelection)
     {
         if (previousSelection != -1 && [_delegate respondsToSelector:@selector(pieChart:willDeselectSliceAtIndex:)])
         {
             [_delegate pieChart:self willDeselectSliceAtIndex:previousSelection];
         }
-        
+
         _selectedSliceIndex = newSelection;
-        
-        if (newSelection != -1) 
+
+        if (newSelection != -1)
         {
             if([_delegate respondsToSelector:@selector(pieChart:willSelectSliceAtIndex:)])
                 [_delegate pieChart:self willSelectSliceAtIndex:newSelection];
@@ -572,7 +572,7 @@ static CGPathRef CGPathCreateArc(CGPoint center, CGFloat radius, CGFloat startAn
                 [_delegate pieChart:self didSelectSliceAtIndex:newSelection];
             [self setSliceSelectedAtIndex:newSelection];
         }
-        
+
         if(previousSelection != -1)
         {
             [self setSliceDeselectedAtIndex:previousSelection];
@@ -584,7 +584,7 @@ static CGPathRef CGPathCreateArc(CGPoint center, CGFloat radius, CGFloat startAn
     {
         SliceLayer *layer = [_pieView.layer.sublayers objectAtIndex:newSelection];
         if(_selectedSliceOffsetRadius > 0 && layer){
-            
+
             if (layer.isSelected) {
                 if ([_delegate respondsToSelector:@selector(pieChart:willDeselectSliceAtIndex:)])
                     [_delegate pieChart:self willDeselectSliceAtIndex:newSelection];
@@ -638,7 +638,7 @@ static CGPathRef CGPathCreateArc(CGPoint center, CGFloat radius, CGFloat startAn
     else
         label = [NSString stringWithFormat:@"%0.0f", value];
     CGSize size = [label sizeWithFont:self.labelFont];
-    
+
     [CATransaction setDisableActions:YES];
     if(M_PI*2*_labelRadius*pieLayer.percentage < MAX(size.width,size.height) || value <= 0)
     {


### PR DESCRIPTION
I was looking at this excellent control in in the simulator and noticed that the transition from one highlighted segment to another seemed a little off.
I noticed that the touches were being resolved to self, rather than the _pieView, which may have been causing the slight offset issue.
I have updated the code to resolve touches in the _pieView and now it changes they highlighted segment as soon as my pointer (running in the simulator) crosses a boundary.
