### PR TITLE
Fixed exc_bad_access issue

### DIFF
--- a/XYPieChart/XYPieChart.m
+++ b/XYPieChart/XYPieChart.m
@@ -334,7 +334,7 @@ static CGPathRef CGPathCreateArc(CGPoint center, CGFloat radius, CGFloat startAn
         
         BOOL isOnStart = ([slicelayers count] == 0 && sliceCount);
         NSInteger diff = sliceCount - [slicelayers count];
-        layersToRemove = [NSMutableArray arrayWithArray:slicelayers];
+        layersToRemove = [[NSMutableArray alloc] initWithArray:slicelayers];
         
         BOOL isOnEnd = ([slicelayers count] && (sliceCount == 0 || sum <= 0));
         if(isOnEnd)


### PR DESCRIPTION
Because the layersToRemove variable in reloadData is created using a convenience constructor, it sometimes isn't retained properly, changed to use an alloc.
