### PR TITLE
Allow reloadData if previous animation ongoing.

### DIFF
--- a/XYPieChart/XYPieChart.m
+++ b/XYPieChart/XYPieChart.m
@@ -281,7 +281,7 @@ static CGPathRef CGPathCreateArc(CGPoint center, CGFloat radius, CGFloat startAn
 
 - (void)reloadData
 {
-    if (_dataSource && !_animationTimer) 
+    if (_dataSource)
     {
         CALayer *parentLayer = [_pieView layer];
         NSArray *slicelayers = [parentLayer sublayers];


### PR DESCRIPTION
Using reloadData during an animation didn't reload the pie chart, meaning added slices would be missing. This makes reloadData work during animations.
