### PR TITLE
Fixed a bug that cancelled the animation timer and made the pie chart disappear whenever the user clicks on the animating chart.

### DIFF
--- a/XYPieChart/XYPieChart.m
+++ b/XYPieChart/XYPieChart.m
@@ -459,7 +459,11 @@ static CGPathRef CGPathCreateArc(CGPoint center, CGFloat radius, CGFloat startAn
 {
     if (_animationTimer == nil) {
         static float timeInterval = 1.0/60.0;
-        _animationTimer= [NSTimer scheduledTimerWithTimeInterval:timeInterval target:self selector:@selector(updateTimerFired:) userInfo:nil repeats:YES];
+        // Run the animation timer on the main thread.
+        // We want to allow the user to interact with the UI while this timer is running.
+        // If we run it on this thread, the timer will be halted while the user is touching the screen (that's why the chart was disappearing in our collection view).
+        _animationTimer= [NSTimer timerWithTimeInterval:timeInterval target:self selector:@selector(updateTimerFired:) userInfo:nil repeats:YES];
+        [[NSRunLoop mainRunLoop] addTimer:_animationTimer forMode:NSRunLoopCommonModes];
     }
     
     [_animations addObject:anim];


### PR DESCRIPTION
Run the animation timer on the main thread.  We want to allow the user
to interact with the UI while this timer is running.  If we run it on
this thread, the timer will be halted while the user is touching the
screen (that's why the chart was disappearing in our collection view).
