### PR TITLE
ReloadData called in quick succession results in empty segments

### DIFF
--- a/XYPieChart/XYPieChart.m
+++ b/XYPieChart/XYPieChart.m
@@ -296,21 +296,6 @@ static CGPathRef CGPathCreateArc(CGPoint center, CGFloat radius, CGFloat startAn
         [_pieView setUserInteractionEnabled:NO];
         
         __block NSMutableArray *layersToRemove = nil;
-        [CATransaction setCompletionBlock:^{
-            
-            [layersToRemove enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
-                [obj removeFromSuperlayer];
-            }];
-            
-            [layersToRemove removeAllObjects];
-            
-            for(SliceLayer *layer in _pieView.layer.sublayers)
-            {
-                [layer setZPosition:kDefaultSliceZOrder];
-            }
-            
-            [_pieView setUserInteractionEnabled:YES];
-        }];
         
         BOOL isOnStart = ([slicelayers count] == 0 && sliceCount);
         NSInteger diff = sliceCount - [slicelayers count];
@@ -421,6 +406,20 @@ static CGPathRef CGPathCreateArc(CGPoint center, CGFloat radius, CGFloat startAn
             CATextLayer *textLayer = [[layer sublayers] objectAtIndex:0];
             [textLayer setHidden:YES];
         }
+        
+        [layersToRemove enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+            [obj removeFromSuperlayer];
+        }];
+        
+        [layersToRemove removeAllObjects];
+        
+        for(SliceLayer *layer in _pieView.layer.sublayers)
+        {
+            [layer setZPosition:kDefaultSliceZOrder];
+        }
+        
+        [_pieView setUserInteractionEnabled:YES];
+        
         [CATransaction setDisableActions:NO];
         [CATransaction commit];
     }


### PR DESCRIPTION
If reloadData was called in quick succession while an animation was already running, the pie chart could end up having empty segments.

For example, if I went from a chart with 3 segments, and quickly changed to a chart that had 1 segment -then back to the three segments again, it would draw the three segment chart with only 1 segment. The other two segments would be empty spaces.

I can only assume this must be because the layersToRemove variable is getting changed in between the time of the CATransaction committing and the completion block happening. I have moved the code that was in the completion block to the end of the CATransaction (after some code that seems to already be doing some cleanup work using layersToRemove), and this seems to fix the problem. Presumably because it is all within the scope of the transaction now.

You now seem to be able to call reloadData as many times and as quickly as you like and it works ok.
