### PR TITLE
Workaround for font name handling change in iOS 7.

### DIFF
--- a/XYPieChart/XYPieChart.m
+++ b/XYPieChart/XYPieChart.m
@@ -629,9 +629,16 @@ static CGPathRef CGPathCreateArc(CGPoint center, CGFloat radius, CGFloat startAn
     [pieLayer setStrokeColor:NULL];
     CATextLayer *textLayer = [CATextLayer layer];
     textLayer.contentsScale = [[UIScreen mainScreen] scale];
-    CGFontRef font = CGFontCreateWithFontName((__bridge CFStringRef)[self.labelFont fontName]);
-    [textLayer setFont:font];
-    CFRelease(font);
+    CGFontRef font = nil;
+    if ([[[UIDevice currentDevice] systemVersion] floatValue] >= 7.0) {
+        font = CGFontCreateCopyWithVariations((__bridge CGFontRef)(self.labelFont), (__bridge CFDictionaryRef)(@{}));
+    } else {
+        font = CGFontCreateWithFontName((__bridge CFStringRef)[self.labelFont fontName]);
+    }
+    if (font) {
+        [textLayer setFont:font];
+        CFRelease(font);
+    }
     [textLayer setFontSize:self.labelFont.pointSize];
     [textLayer setAnchorPoint:CGPointMake(0.5, 0.5)];
     [textLayer setAlignmentMode:kCAAlignmentCenter];


### PR DESCRIPTION
Font name handling changed in iOS 7. The assertion below will pass in pre-iOS7 installs but fail in iOS 7. This pull request is a workaround for the new behavior.

```
UIFont *uifont = [UIFont boldSystemFontOfSize: 14.0f];
CGFontRef cgfont = CGFontCreateWithFontName((__bridge CFStringRef)[uifont fontName]);
NSAssert(cgfont, @"could not create cgfont from bold system font name");
```

The behavior of both the old and the new approach should be the same, but the new approach is only used in iOS 7 just to be on the safe side.
