### PR TITLE
Compile errors in Xcode 5 beta 3

### DIFF
--- a/XYPieChart/XYPieChart.m
+++ b/XYPieChart/XYPieChart.m
@@ -432,7 +432,7 @@ static CGPathRef CGPathCreateArc(CGPoint center, CGFloat radius, CGFloat startAn
     CALayer *parentLayer = [_pieView layer];
     NSArray *pieLayers = [parentLayer sublayers];
 
-    [pieLayers enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+    [pieLayers enumerateObjectsUsingBlock:^(CAShapeLayer * obj, NSUInteger idx, BOOL *stop) {
         
         NSNumber *presentationLayerStartAngle = [[obj presentationLayer] valueForKey:@"startAngle"];
         CGFloat interpolatedStartAngle = [presentationLayerStartAngle doubleValue];


### PR DESCRIPTION
When compiling with the latest Xcode 5 preview 3 I got the following errors

XYPieChart.m:444:22: Implicit conversion of C pointer type 'CGPathRef' (aka 'const struct CGPath *') to Objective-C pointer type 'NSString *' requires a bridged cast
XYPieChart.m:444:22: Incompatible pointer types sending 'CGPathRef' (aka 'const struct CGPath *') to parameter of type 'NSString *'

This change to more strictly type the object seems to fix it
