### PR TITLE
Adding IBOutlets to the .h for Interface Builder/Storyboard support

### DIFF
--- a/XYPieChart/XYPieChart.h
+++ b/XYPieChart/XYPieChart.h
@@ -47,8 +47,8 @@
 @end
 
 @interface XYPieChart : UIView
-@property(nonatomic, weak) id<XYPieChartDataSource> dataSource;
-@property(nonatomic, weak) id<XYPieChartDelegate> delegate;
+@property(nonatomic, weak) IBOutlet id<XYPieChartDataSource> dataSource;
+@property(nonatomic, weak) IBOutlet id<XYPieChartDelegate> delegate;
 @property(nonatomic, assign) CGFloat startPieAngle;
 @property(nonatomic, assign) CGFloat animationSpeed;
 @property(nonatomic, assign) CGPoint pieCenter;


### PR DESCRIPTION
Just adding IBOutlet references so we can use Storyboard/Interface Builder to wire up the interface and the dataSource/delegates.
