### PR TITLE
Added support for a Pie Chart Data Source based on a dictionary.

### DIFF
--- a/Demo/XYPieChart.xcodeproj/project.pbxproj
+++ b/Demo/XYPieChart.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		2424BF2C1607437C0000B539 /* XYPieChart.m in Sources */ = {isa = PBXBuildFile; fileRef = 2424BF2B1607437C0000B539 /* XYPieChart.m */; };
+		36F354D41942C72B00F4FD5B /* XYPieChartForDictView.m in Sources */ = {isa = PBXBuildFile; fileRef = 36F354D31942C72B00F4FD5B /* XYPieChartForDictView.m */; };
 		8768825C1501D2A60097BE69 /* icon.png in Resources */ = {isa = PBXBuildFile; fileRef = 8768825B1501D2A60097BE69 /* icon.png */; };
 		87FEAA1C14F84E3000ED38A2 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 87FEAA1B14F84E3000ED38A2 /* UIKit.framework */; };
 		87FEAA1E14F84E3000ED38A2 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 87FEAA1D14F84E3000ED38A2 /* Foundation.framework */; };
@@ -23,6 +24,8 @@
 /* Begin PBXFileReference section */
 		2424BF2A1607437C0000B539 /* XYPieChart.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XYPieChart.h; path = ../../XYPieChart/XYPieChart.h; sourceTree = "<group>"; };
 		2424BF2B1607437C0000B539 /* XYPieChart.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XYPieChart.m; path = ../../XYPieChart/XYPieChart.m; sourceTree = "<group>"; };
+		36F354D21942C72B00F4FD5B /* XYPieChartForDictView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = XYPieChartForDictView.h; path = ../../XYPieChart/XYPieChartForDictView.h; sourceTree = "<group>"; };
+		36F354D31942C72B00F4FD5B /* XYPieChartForDictView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = XYPieChartForDictView.m; path = ../../XYPieChart/XYPieChartForDictView.m; sourceTree = "<group>"; };
 		8768825B1501D2A60097BE69 /* icon.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = icon.png; sourceTree = "<group>"; };
 		87FEAA1714F84E3000ED38A2 /* XYPieChart.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = XYPieChart.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		87FEAA1B14F84E3000ED38A2 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
@@ -89,6 +92,8 @@
 			children = (
 				2424BF2A1607437C0000B539 /* XYPieChart.h */,
 				2424BF2B1607437C0000B539 /* XYPieChart.m */,
+				36F354D21942C72B00F4FD5B /* XYPieChartForDictView.h */,
+				36F354D31942C72B00F4FD5B /* XYPieChartForDictView.m */,
 				87FEAA2D14F84E3100ED38A2 /* ViewController.h */,
 				87FEAA2E14F84E3100ED38A2 /* ViewController.m */,
 				87FEAA3014F84E3100ED38A2 /* ViewController.xib */,
@@ -175,6 +180,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				87FEAA2814F84E3100ED38A2 /* main.m in Sources */,
+				36F354D41942C72B00F4FD5B /* XYPieChartForDictView.m in Sources */,
 				87FEAA2C14F84E3100ED38A2 /* AppDelegate.m in Sources */,
 				87FEAA2F14F84E3100ED38A2 /* ViewController.m in Sources */,
 				2424BF2C1607437C0000B539 /* XYPieChart.m in Sources */,

--- a/XYPieChart/XYPieChart.h
+++ b/XYPieChart/XYPieChart.h
@@ -65,6 +65,8 @@
 - (void)reloadData;
 - (void)setPieBackgroundColor:(UIColor *)color;
 
+- (UIColor *)colorAtIndex:(int)index;
+
 - (void)setSliceSelectedAtIndex:(NSInteger)index;
 - (void)setSliceDeselectedAtIndex:(NSInteger)index;
 

--- a/XYPieChart/XYPieChart.m
+++ b/XYPieChart/XYPieChart.m
@@ -369,16 +369,7 @@ static CGPathRef CGPathCreateArc(CGPoint center, CGFloat radius, CGFloat startAn
             
             layer.value = values[index];
             layer.percentage = (sum)?layer.value/sum:0;
-            UIColor *color = nil;
-            if([_dataSource respondsToSelector:@selector(pieChart:colorForSliceAtIndex:)])
-            {
-                color = [_dataSource pieChart:self colorForSliceAtIndex:index];
-            }
-            
-            if(!color)
-            {
-                color = [UIColor colorWithHue:((index/8)%20)/20.0+0.02 saturation:(index%8+3)/10.0 brightness:91/100.0 alpha:1];
-            }
+            UIColor *color = [self colorAtIndex:index];
             
             [layer setFillColor:color.CGColor];
             if([_dataSource respondsToSelector:@selector(pieChart:textForSliceAtIndex:)])
@@ -424,6 +415,26 @@ static CGPathRef CGPathCreateArc(CGPoint center, CGFloat radius, CGFloat startAn
         [CATransaction commit];
     }
 }
+
+
+- (UIColor *)colorAtIndex:(int)index
+{
+    UIColor *color = nil;
+    
+    if([_dataSource respondsToSelector:@selector(pieChart:colorForSliceAtIndex:)])
+    {
+        color = [_dataSource pieChart:self colorForSliceAtIndex:index];
+    }
+    
+    if(!color)
+    {
+        color = [UIColor colorWithHue:((index/8)%20)/20.0+0.02 saturation:(index%8+3)/10.0 brightness:91/100.0 alpha:1];
+    }
+
+    return color;
+}
+
+
 
 #pragma mark - Animation Delegate + Run Loop Timer
 

--- a/XYPieChart/XYPieChart.m
+++ b/XYPieChart/XYPieChart.m
@@ -654,11 +654,18 @@ static CGPathRef CGPathCreateArc(CGPoint center, CGFloat radius, CGFloat startAn
     CATextLayer *textLayer = [[pieLayer sublayers] objectAtIndex:0];
     [textLayer setHidden:!_showLabel];
     if(!_showLabel) return;
-    NSString *label;
-    if(_showPercentage)
-        label = [NSString stringWithFormat:@"%0.0f", pieLayer.percentage*100];
+    
+    NSMutableString *label;
+    if( pieLayer.text.length == 0 )
+        label = [NSMutableString stringWithString:@""];
     else
-        label = (pieLayer.text)?pieLayer.text:[NSString stringWithFormat:@"%0.0f", value];
+        label = [NSMutableString stringWithFormat:@"%@ - ", pieLayer.text];
+    
+    
+    if(_showPercentage)
+        [label appendFormat:@"%0.0f", pieLayer.percentage*100];
+    else
+        [label appendFormat:@"%0.0f", value];
     
     CGSize size = [label sizeWithFont:self.labelFont];
     

--- a/XYPieChart/XYPieChart.m
+++ b/XYPieChart/XYPieChart.m
@@ -674,7 +674,7 @@ static CGPathRef CGPathCreateArc(CGPoint center, CGFloat radius, CGFloat startAn
     
     
     if(_showPercentage)
-        [label appendFormat:@"%0.0f", pieLayer.percentage*100];
+        [label appendFormat:@"%0.0f%%", pieLayer.percentage*100];
     else
         [label appendFormat:@"%0.0f", value];
     

--- a/XYPieChart/XYPieChartForDictView.h
+++ b/XYPieChart/XYPieChartForDictView.h
@@ -21,6 +21,6 @@
 - (void)setDataSourceDict:(NSDictionary *)dataSourceDict keyOrder:(NSArray *)keyOrder;
 - (void)setDataSourceDict:(NSDictionary *)dataSourceDict;
 
-- (UIView *)makeLabelKeyViewAtPoint:(CGPoint)point;
+- (UIView *)makeLabelKeyViewAtPoint:(CGPoint)point boxCornerRadius:(float)cornerRadius;
 
 @end

--- a/XYPieChart/XYPieChartForDictView.h
+++ b/XYPieChart/XYPieChartForDictView.h
@@ -22,6 +22,6 @@
 
 - (void)setKeyOrder:(NSArray *)keyOrder;
 
-- (UIView *)makeLabelKeyViewAtPoint:(CGPoint)point boxCornerRadius:(float)cornerRadius;
+- (UIView *)makeLabelKeyViewAtPoint:(CGPoint)point boxCornerRadius:(float)cornerRadius showValue:(bool)showValue;
 
 @end

--- a/XYPieChart/XYPieChartForDictView.h
+++ b/XYPieChart/XYPieChartForDictView.h
@@ -18,8 +18,9 @@
 @property (nonatomic) NSDictionary *colorDict;
 @property (nonatomic) bool showDictLabel;
 
-- (void)setDataSourceDict:(NSDictionary *)dataSourceDict keyOrder:(NSArray *)keyOrder;
 - (void)setDataSourceDict:(NSDictionary *)dataSourceDict;
+
+- (void)setKeyOrder:(NSArray *)keyOrder;
 
 - (UIView *)makeLabelKeyViewAtPoint:(CGPoint)point boxCornerRadius:(float)cornerRadius;
 

--- a/XYPieChart/XYPieChartForDictView.h
+++ b/XYPieChart/XYPieChartForDictView.h
@@ -1,0 +1,26 @@
+//
+//  XYPieChartForDictView.h
+//  XYPieChart
+//
+//  Created by Tod Cunningham on 6/7/14.
+//  Copyright (c) 2014 Xiaoyang Feng. All rights reserved.
+//
+#import <UIKit/UIKit.h>
+#import "XYPieChart.h"
+
+
+@interface XYPieChartForDictView : XYPieChart <XYPieChartDataSource>
+{
+    NSArray      *m_dataSourceOrderedKeys;
+    NSDictionary *m_dataSourceDict;
+}
+
+@property (nonatomic) NSDictionary *colorDict;
+@property (nonatomic) bool showDictLabel;
+
+- (void)setDataSourceDict:(NSDictionary *)dataSourceDict keyOrder:(NSArray *)keyOrder;
+- (void)setDataSourceDict:(NSDictionary *)dataSourceDict;
+
+- (UIView *)makeLabelKeyViewAtPoint:(CGPoint)point;
+
+@end

--- a/XYPieChart/XYPieChartForDictView.m
+++ b/XYPieChart/XYPieChartForDictView.m
@@ -95,7 +95,7 @@
 
 
 
-- (UIView *)makeLabelKeyViewAtPoint:(CGPoint)point
+- (UIView *)makeLabelKeyViewAtPoint:(CGPoint)point boxCornerRadius:(float)cornerRadius
 {
     CGSize maxLabelSize  = CGSizeMake(0, 0);
     
@@ -111,14 +111,19 @@
             maxLabelSize.height = textSize.height;
     }
 
-    float    xMargin  = 8;
-    float    yMargin  = 8;
-    CGSize   viewSize = CGSizeMake(m_dataSourceOrderedKeys.count * (maxLabelSize.width + xMargin), m_dataSourceOrderedKeys.count * (maxLabelSize.height + yMargin) );
+    CGSize boxSize = CGSizeMake( maxLabelSize.height, maxLabelSize.height );
+    float  xMargin  = 2;
+    float  yMargin  = 2;
+    float  boxTextGap = xMargin * 2;
+    
+    CGSize   viewSize = CGSizeMake((m_dataSourceOrderedKeys.count * (maxLabelSize.width + xMargin)) + (boxSize.width + boxTextGap), m_dataSourceOrderedKeys.count * (maxLabelSize.height + yMargin) );
     UIView  *view     = [[UIView alloc] initWithFrame:CGRectMake(point.x, point.y, viewSize.width, viewSize.height)];
-
+    
     for( int index = 0;  index < m_dataSourceOrderedKeys.count;  index += 1 )
     {
-        UILabel  *label = [[UILabel alloc] initWithFrame:CGRectMake(0, index * (maxLabelSize.height + yMargin), maxLabelSize.width, maxLabelSize.height)];
+        CGRect    frame = CGRectMake((boxSize.width + boxTextGap), index * (maxLabelSize.height + yMargin), maxLabelSize.width, maxLabelSize.height);
+        
+        UILabel  *label = [[UILabel alloc] initWithFrame:frame];
         NSString *key   = [m_dataSourceOrderedKeys objectAtIndex:index];
         
         label.text = key;
@@ -127,6 +132,22 @@
         
         [view addSubview:label];
     }
+    
+    for( int index = 0;  index < m_dataSourceOrderedKeys.count;  index += 1 )
+    {
+        CGRect  frame = CGRectMake(0, index * (maxLabelSize.height + yMargin), boxSize.width, boxSize.height);
+        UIView *boxView = [[UIView alloc] initWithFrame:frame];
+        boxView.backgroundColor = [self colorAtIndex:index];
+        
+        if( cornerRadius > 0 )
+        {
+            boxView.layer.cornerRadius = cornerRadius;
+            boxView.clipsToBounds = YES;
+        }
+        
+        [view addSubview:boxView];
+    }
+
     
     return view;
 }

--- a/XYPieChart/XYPieChartForDictView.m
+++ b/XYPieChart/XYPieChartForDictView.m
@@ -84,22 +84,27 @@
     
     NSString *key = [m_dataSourceOrderedKeys objectAtIndex:index];
     
-    NSLog( @"pieChart text for slice %d:%@", index, key );
-    
     return key;
 }
 
 
 
 
-- (UIView *)makeLabelKeyViewAtPoint:(CGPoint)point boxCornerRadius:(float)cornerRadius
+- (UIView *)makeLabelKeyViewAtPoint:(CGPoint)point boxCornerRadius:(float)cornerRadius showValue:(bool)showValue
 {
     CGSize maxLabelSize  = CGSizeMake(0, 0);
     
     // Find the largest label size
-    for( NSString *key in m_dataSourceOrderedKeys )
+    for( int index = 0;  index < m_dataSourceOrderedKeys.count;  index += 1 )
     {
-        CGSize textSize = [key sizeWithAttributes:@{NSFontAttributeName:self.labelFont}];
+        NSString *key   = [m_dataSourceOrderedKeys objectAtIndex:index];
+        NSString *text  = key;
+        CGFloat   value = [self pieChart:self valueForSliceAtIndex:index];
+        
+        if( showValue && value > 0)
+            text = [NSString stringWithFormat:@"%@ (%0.0f)", key, value];
+        
+        CGSize textSize = [text sizeWithAttributes:@{NSFontAttributeName:self.labelFont}];
         
         if( maxLabelSize.width < textSize.width )
             maxLabelSize.width = textSize.width;
@@ -122,8 +127,13 @@
         
         UILabel  *label = [[UILabel alloc] initWithFrame:frame];
         NSString *key   = [m_dataSourceOrderedKeys objectAtIndex:index];
+        NSString *text  = key;
+        CGFloat   value = [self pieChart:self valueForSliceAtIndex:index];
         
-        label.text = key;
+        if( showValue && value > 0)
+            text = [NSString stringWithFormat:@"%@ (%0.0f)", key, value];
+        
+        label.text = text;
         label.font = self.labelFont;
         label.textColor = self.labelColor;
         

--- a/XYPieChart/XYPieChartForDictView.m
+++ b/XYPieChart/XYPieChartForDictView.m
@@ -14,30 +14,27 @@
 
 
 
-
-
-
-- (void)setDataSourceDict:(NSDictionary *)dataSourceDict keyOrder:(NSArray *)keyOrder
+- (void)setDataSourceDict:(NSDictionary *)dataSourceDict
 {
-    assert( [[NSSet setWithArray:dataSourceDict.allKeys] isEqualToSet:[NSSet setWithArray:keyOrder]] );
-    
     if( self.dataSource == nil )
         self.dataSource = self;
     
     // When using a data source dictionary we need to be the dataSource delegate.
     assert( self.dataSource == self );
-
-    m_dataSourceOrderedKeys = keyOrder;
-    m_dataSourceDict        = [dataSourceDict copy];
-    [self reloadData];
+    
+    m_dataSourceDict = [dataSourceDict copy];
+    [self setKeyOrder:[dataSourceDict keysSortedByValueUsingSelector:@selector(compare:)]];
 }
 
 
 
 
-- (void)setDataSourceDict:(NSDictionary *)dataSourceDict
+- (void)setKeyOrder:(NSArray *)keyOrder
 {
-    [self setDataSourceDict:dataSourceDict keyOrder:[dataSourceDict keysSortedByValueUsingSelector:@selector(compare:)]];
+    assert( [[NSSet setWithArray:m_dataSourceDict.allKeys] isEqualToSet:[NSSet setWithArray:keyOrder]] );
+
+    m_dataSourceOrderedKeys = keyOrder;
+    [self reloadData];
 }
 
 

--- a/XYPieChart/XYPieChartForDictView.m
+++ b/XYPieChart/XYPieChartForDictView.m
@@ -1,0 +1,135 @@
+//
+//  XYPieChartForDictView.m
+//  XYPieChart
+//
+//  Created by Tod Cunningham on 6/7/14.
+//  Copyright (c) 2014 Xiaoyang Feng. All rights reserved.
+//
+#import "XYPieChartForDictView.h"
+
+
+
+@implementation XYPieChartForDictView
+
+
+
+
+
+
+
+- (void)setDataSourceDict:(NSDictionary *)dataSourceDict keyOrder:(NSArray *)keyOrder
+{
+    assert( [[NSSet setWithArray:dataSourceDict.allKeys] isEqualToSet:[NSSet setWithArray:keyOrder]] );
+    
+    if( self.dataSource == nil )
+        self.dataSource = self;
+    
+    // When using a data source dictionary we need to be the dataSource delegate.
+    assert( self.dataSource == self );
+
+    m_dataSourceOrderedKeys = keyOrder;
+    m_dataSourceDict        = [dataSourceDict copy];
+    [self reloadData];
+}
+
+
+
+
+- (void)setDataSourceDict:(NSDictionary *)dataSourceDict
+{
+    [self setDataSourceDict:dataSourceDict keyOrder:[dataSourceDict keysSortedByValueUsingSelector:@selector(compare:)]];
+}
+
+
+
+
+- (NSUInteger)numberOfSlicesInPieChart:(XYPieChart *)pieChart
+{
+    return m_dataSourceOrderedKeys.count;
+}
+
+
+
+- (CGFloat)pieChart:(XYPieChart *)pieChart valueForSliceAtIndex:(NSUInteger)index
+{
+    NSString *key = [m_dataSourceOrderedKeys objectAtIndex:index];
+    assert( key );
+    NSNumber *value = [m_dataSourceDict objectForKey:key];
+    assert( [value isKindOfClass:NSNumber.class] );
+    
+    return value.floatValue;
+}
+
+
+
+- (UIColor *)pieChart:(XYPieChart *)pieChart colorForSliceAtIndex:(NSUInteger)index
+{
+    UIColor *color = nil;
+    
+    if( index < m_dataSourceOrderedKeys.count )
+    {
+        NSString *key = [m_dataSourceOrderedKeys objectAtIndex:index];
+        color = [_colorDict objectForKey:key];
+        if( color != nil )
+            assert( [color isKindOfClass:UIColor.class] );
+    }
+    
+    return color;
+}
+
+
+
+
+- (NSString *)pieChart:(XYPieChart *)pieChart textForSliceAtIndex:(NSUInteger)index
+{
+    if( !_showDictLabel )
+        return nil;
+    
+    NSString *key = [m_dataSourceOrderedKeys objectAtIndex:index];
+    
+    NSLog( @"pieChart text for slice %d:%@", index, key );
+    
+    return key;
+}
+
+
+
+
+- (UIView *)makeLabelKeyViewAtPoint:(CGPoint)point
+{
+    CGSize maxLabelSize  = CGSizeMake(0, 0);
+    
+    // Find the largest label size
+    for( NSString *key in m_dataSourceOrderedKeys )
+    {
+        CGSize textSize = [key sizeWithAttributes:@{NSFontAttributeName:self.labelFont}];
+        
+        if( maxLabelSize.width < textSize.width )
+            maxLabelSize.width = textSize.width;
+        
+        if( maxLabelSize.height < textSize.height )
+            maxLabelSize.height = textSize.height;
+    }
+
+    float    xMargin  = 8;
+    float    yMargin  = 8;
+    CGSize   viewSize = CGSizeMake(m_dataSourceOrderedKeys.count * (maxLabelSize.width + xMargin), m_dataSourceOrderedKeys.count * (maxLabelSize.height + yMargin) );
+    UIView  *view     = [[UIView alloc] initWithFrame:CGRectMake(point.x, point.y, viewSize.width, viewSize.height)];
+
+    for( int index = 0;  index < m_dataSourceOrderedKeys.count;  index += 1 )
+    {
+        UILabel  *label = [[UILabel alloc] initWithFrame:CGRectMake(0, index * (maxLabelSize.height + yMargin), maxLabelSize.width, maxLabelSize.height)];
+        NSString *key   = [m_dataSourceOrderedKeys objectAtIndex:index];
+        
+        label.text = key;
+        label.font = self.labelFont;
+        label.textColor = self.labelColor;
+        
+        [view addSubview:label];
+    }
+    
+    return view;
+}
+
+
+@end


### PR DESCRIPTION
Made it really easy to create a pie chart from a dictionary of entries, and added ability to add a key chart view of the pie chart based on the dictionary.

The following is an example of setting up a pie chart based on a dictionary.

```
_roundsWonLostPieChartView.colorDict      = @{@"Rounds Won": UIColor.redColor,                                         @"Rounds Lost" : UIColor.blackColor };
_roundsWonLostPieChartView.dataSourceDict = @{@"Rounds Won": @(m_playerStats.roundsPlayed - m_playerStats.lostRounds), @"Rounds Lost" : @(m_playerStats.lostRounds)};

_wonPointsInRoundPieChartView.colorDict      = @{@"Won 1 Point": UIColor.redColor,              @"Won 2 Points" : UIColor.blackColor,            @"Won 4 Points" : UIColor.blueColor };
_wonPointsInRoundPieChartView.dataSourceDict = @{@"Won 1 Point": @(m_playerStats.wonRounds1pt), @"Won 2 Points" : @(m_playerStats.wonRounds2pt), @"Won 4 Points" : @(m_playerStats.wonRounds4pt) };
_wonPointsInRoundPieChartView.keyOrder       = @[@"Won 1 Point", @"Won 2 Points", @"Won 4 Points"];
```

The following is an example of dynamically creating a key legend based on the dictionary and adding it to the right of the pie chart.

```
    CGPoint point   = CGPointMake( xyPieChartView.frame.origin.x + xyPieChartView.frame.size.width, xyPieChartView.layer.position.y );
    UIView *keyView = [xyPieChartView makeLabelKeyViewAtPoint:point boxCornerRadius:2.0];
    CGRect  frame   = keyView.frame;
    frame.origin.y -= frame.size.height/2;
    keyView.frame = frame;

    [_scrollContentsView addSubview:keyView];
```
